### PR TITLE
remove unused parameter: 'normal_2'

### DIFF
--- a/Volume_08/Number_1/Guigue2003/tri_tri_intersect.c
+++ b/Volume_08/Number_1/Guigue2003/tri_tri_intersect.c
@@ -56,7 +56,7 @@ int tri_tri_intersection_test_3d(double p1[3], double q1[3], double r1[3],
 
 int coplanar_tri_tri3d(double  p1[3], double  q1[3], double  r1[3],
            double  p2[3], double  q2[3], double  r2[3],
-           double  N1[3], double  N2[3]);
+           double  N1[3]);
 
 
 // Two dimensional Triangle-Triangle Overlap Test
@@ -128,7 +128,7 @@ int tri_tri_overlap_test_2d(double p1[2], double q1[2], double r1[2],
     else  { \
       if (dr2 > 0.0f) CHECK_MIN_MAX(p1,q1,r1,r2,p2,q2)\
       else if (dr2 < 0.0f) CHECK_MIN_MAX(p1,r1,q1,r2,p2,q2)\
-      else return coplanar_tri_tri3d(p1,q1,r1,p2,q2,r2,N1,N2);\
+      else return coplanar_tri_tri3d(p1,q1,r1,p2,q2,r2,N1);\
      }}}
   
 
@@ -205,7 +205,7 @@ int tri_tri_overlap_test_3d(double p1[3], double q1[3], double r1[3],
     else  {
       if (dr1 > 0.0f) TRI_TRI_3D(r1,p1,q1,p2,q2,r2,dp2,dq2,dr2)
       else if (dr1 < 0.0f) TRI_TRI_3D(r1,p1,q1,p2,r2,q2,dp2,dr2,dq2)
-      else return coplanar_tri_tri3d(p1,q1,r1,p2,q2,r2,N1,N2);
+      else return coplanar_tri_tri3d(p1,q1,r1,p2,q2,r2,N1);
     }
   }
 };
@@ -214,7 +214,7 @@ int tri_tri_overlap_test_3d(double p1[3], double q1[3], double r1[3],
 
 int coplanar_tri_tri3d(double p1[3], double q1[3], double r1[3],
            double p2[3], double q2[3], double r2[3],
-           double normal_1[3], double normal_2[3]){
+           double normal_1[3]){
   
   double P1[2],Q1[2],R1[2];
   double P2[2],Q2[2],R2[2];
@@ -380,7 +380,7 @@ int coplanar_tri_tri3d(double p1[3], double q1[3], double r1[3],
       else if (dr2 < 0.0f) CONSTRUCT_INTERSECTION(p1,r1,q1,r2,p2,q2)\
       else { \
         *coplanar = 1; \
-  return coplanar_tri_tri3d(p1,q1,r1,p2,q2,r2,N1,N2);\
+  return coplanar_tri_tri3d(p1,q1,r1,p2,q2,r2,N1);\
      } \
   }} }
   
@@ -465,7 +465,7 @@ int tri_tri_intersection_test_3d(double p1[3], double q1[3], double r1[3],
   // triangles are co-planar
 
   *coplanar = 1;
-  return coplanar_tri_tri3d(p1,q1,r1,p2,q2,r2,N1,N2);
+  return coplanar_tri_tri3d(p1,q1,r1,p2,q2,r2,N1);
       }
     }
   }


### PR DESCRIPTION
It's redundant,
and causes warning C4100, 'unreferenced formal parameter'.